### PR TITLE
Add Arctouch e Aubay

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AlgaWorks | https://algaworks.recruiterbox.com/
 Amparo Saúde | https://www.amparosaude.com.br/ 
 Ampla Visão | http://www.amplavisao.com/
 App2Sales | http://app2sales.com/
+Arctouch | https://arctouch.com/
 Beblue | http://beblue.com.br/
 BeYou | http://www.beyou.com.br
 Bidu Corretora | https://www.bidu.com.br/
@@ -113,6 +114,7 @@ Name | Website
 10up  | http://10up.com/careers/
 15five | http://www.15five.com/
 Anchor Loans | http://www.anchorloans.com/
+Aubay | https://www.aubay.pt/
 Auth0 | https://auth0.com/jobs
 Automattic  | https://automattic.com/work-with-us/
 BairesDev | http://www.bairesdev.com/


### PR DESCRIPTION
Aubay - Empresa portuguesa que admite (em alguns casos) brasileiros remotamente e também fornece ajuda para mudança de país.

Arctouch - Empresa de San Francisco que tem escritorio em Florianópolis.