### PR TITLE
Updated Worldwide companies to include Vigil

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ TinkerList.tv | https://tinkerlist.tv/jobs/
 Toggl | https://toggl.com/jobs/
 Toptal | http://www.toptal.com/
 Truelogic | https://www.truelogicsoftware.com/
+Vigil | https://vigil.global
 X-Team | http://www.x-team.com/
 Yoko Co. | https://yokoco.com/careers/
 Zapier | https://zapier.com/jobs/


### PR DESCRIPTION
Including Vigil, a Lisbon-based company that is Hiring Brazilian Developers to work remotely from Brazil with state-of-the-art projects.