### PR TITLE
Adding Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ aftersale | https://www.indeedjobs.com/aftersale/jobs/
 Agrid | https://www.linkedin.com/company/2769994/
 Akkurat | https://www.akkuratsofthouse.com/
 AlgaWorks | https://algaworks.recruiterbox.com/
+Amazon | https://www.amazon.jobs/en/search?base_query=&loc_query=Brazil&country=BRA/
 Amparo Saúde | https://www.amparosaude.com.br/
 Ampla Visão | http://www.amplavisao.com/
 Arctouch | https://arctouch.com/


### PR DESCRIPTION
Amazon is offering teams more flexibility on where to work. Many teams within Amazon and AWS are currently accepting remote work. Not only for tech jobs, but also for non-tech jobs.